### PR TITLE
Set headers after open()

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,11 +3,11 @@ export default function fetch(url, options) {
 	return new Promise( (resolve, reject) => {
 		let request = new XMLHttpRequest();
 
+		request.open(options.method || 'get', url);
+
 		for (let i in options.headers) {
 			request.setRequestHeader(i, options.headers[i]);
 		}
-
-		request.open(options.method || 'get', url);
 
 		request.onload = () => {
 			resolve(response(request));


### PR DESCRIPTION
Using headers throws an exception (at least in Safari). The request needs to be open()ed before setting headers.

See e.g. https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/setRequestHeader