### PR TITLE
Add support for fetch’s credentials option

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,10 @@ export default function fetch(url, options) {
 			request.setRequestHeader(i, options.headers[i]);
 		}
 
+		if (options.credentials === 'include') {
+			request.withCredentials = true;
+		}
+
 		request.onload = () => {
 			resolve(response(request));
 		};

--- a/src/index.js
+++ b/src/index.js
@@ -9,9 +9,7 @@ export default typeof fetch=='function' ? fetch : function(url, options) {
 			request.setRequestHeader(i, options.headers[i]);
 		}
 
-		if (options.credentials === 'include') {
-			request.withCredentials = true;
-		}
+		request.withCredentials = options.credentials != 'omit';
 
 		request.onload = () => {
 			resolve(response());


### PR DESCRIPTION
`credentials` can be one of three values: `omit`, `same-origin` and `include`. I’m only polyfilling `include` because `same-origin` is the default XHR behavior, and it looks like there’s no way to polyfill `omit` (I haven’t found a way to prevent XHR from sending cookies on the same domain; additionally, [github/fetch](https://github.com/github/fetch) doesn’t polyfill `omit` too).

Closes #4.

