### PR TITLE
A better .has(n)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -47,7 +47,7 @@ export default function fetch(url, options) {
 					keys: () => keys,
 					entries: () => all,
 					get: n => headers[n.toLowerCase()],
-					has: n => !!headers[n.toLowerCase()]
+					has: n => n.toLowerCase() in headers
 				}
 			};
 		}


### PR DESCRIPTION
Still keeping it simple, no need to double `!!` over a property access, simply use the `in` operator.

It's still not as robust as `hasOwnProperty`, ~~so that every header would virtually have `toString` in there (since you use objects and not empty dictionaries)~~, but it minifies better and it's probably faster on outdated browsers.

edit: actually lowercasing the header name guards already against common methods so ... `in` operator it is!