### PR TITLE
Use default function params

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,4 @@
-export default function fetch(url, options) {
-	options = options || {};
+export default function fetch(url, options = {}) {
 	return new Promise( (resolve, reject) => {
 		let request = new XMLHttpRequest();
 


### PR DESCRIPTION
Not sure if you needed the `options = options || {}` approach for some reason.  If not - it's now smaller!