### PR TITLE
fix: `ok` returns true for status >= 400

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -35,7 +35,7 @@ export default function fetch(url, options) {
 
 			return {
 				type: 'cors',
-				ok: xhr.status/200|0 == 1,		// 200-399
+				ok: (xhr.status >= 200) && (xhr.status < 400),
 				status: xhr.status,
 				statusText: xhr.statusText,
 				url: xhr.responseURL,


### PR DESCRIPTION
Due to operator precedence, `xhr.status/200|0 == 1` actually reads as `xhr.status/200|(0 == 1)`, which is true for all values that are >= 200.

You were trying to shave off a few bytes, but please consider the suggested change in favor of code readability.
