### PR TITLE
Add unfetch/maybe, conditionally returns window.fetch || unfetch

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "mkdirp": "^0.5.1",
     "mocha": "^3.2.0",
     "npm-run-all": "^2.1.1",
+    "proxyquire": "~1.7.11",
     "rimraf": "^2.5.2",
     "rollup": "^0.41.4",
     "rollup-plugin-buble": "^0.15.0",

--- a/src/maybe.js
+++ b/src/maybe.js
@@ -1,0 +1,4 @@
+import unfetch from './'
+export default typeof window === 'object' && typeof window.fetch === 'function'
+  ? window.fetch
+  : unfetch;

--- a/test/maybe.js
+++ b/test/maybe.js
@@ -1,0 +1,22 @@
+import proxyquire from 'proxyquire';
+import { expect } from 'chai';
+import fetch from '../src';
+
+describe('unfetch/maybe', () => {
+  it('uses unfetch when global.window.fetch is not available', () => {
+    const result = proxyquire('../src/maybe', {}).default;
+    expect(result).to.equal(fetch);
+  });
+
+  it('uses global.window.fetch when available', () => {
+    const mockFetch = () => {};
+    global.window = {
+      fetch: mockFetch
+    };
+
+    const result = proxyquire('../src/maybe', {}).default;
+    expect(result).to.equal(mockFetch);
+
+    delete global.window;
+  });
+});


### PR DESCRIPTION
I don't think `maybe` is the right name for this, but I figured I'd open a PR to start the discussion.

I also don't know how to add `unfetch/maybe` to the build so users can require it (I'm used to writing ES5 modules).

The idea is that this code would assign the variable `fetch` to the value of `window.fetch` if it exists, otherwise `unfetch`. The reason I want to do this is because I'm assuming the native `fetch` implementation (if exists) would probably be slightly faster, and it would be better to use it if it's there.

```js
import fetch from 'unfetch/maybe'
```

That way I don't have to do this in my code:

```js
const fetch = typeof window.fetch === 'function'
  ? window.fetch
  : require('unfetch')
```

I can also add docs for this if/when you agree on a name for this file (or if you think it should be an external module, I can just do that as well).