### PR TITLE
RFC: v2 - ponyfill/polyfill entries, credentials & more

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,20 @@ fetch('/foo.json')
   });
 ```
 
+Globally, as a [**polyfill**](https://ponyfill.com):
+
+```js
+import 'unfetch/polyfill';
+
+// "fetch" is now installed globally if it wasn't already available
+
+fetch('/foo.json')
+  .then( r => r.json() )
+  .then( data => {
+    console.log(data);
+  });
+```
+
 ## Examples & Demos
 
 [**Real Example on JSFiddle**](https://jsfiddle.net/developit/qrh7tLc0/) ➡️

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ fetch('/foo.json')
   });
 ```
 
-Globally, as a [**polyfill**](https://ponyfill.com):
+Globally, as a [**polyfill**](https://ponyfill.com/#polyfill):
 
 ```js
 import 'unfetch/polyfill';

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
   "license": "MIT",
   "files": [
     "src",
-    "dist"
+    "dist",
+    "polyfill.js"
   ],
   "eslintConfig": {
     "parser": "babel-eslint",

--- a/polyfill.js
+++ b/polyfill.js
@@ -1,0 +1,1 @@
+if (!window.fetch) window.fetch = require('.');

--- a/src/index.js
+++ b/src/index.js
@@ -22,7 +22,7 @@ export default typeof fetch=='function' ? fetch : function(url, options) {
 				keys = [],
 				all = [],
 				headers = {},
-				reg = /^(.*?):\s*([\s\S]*)$/gm,
+				reg = /^(.*?):\s*([\s\S]*?)$/gm,
 				match, header, key;
 
 			while ((match=reg.exec(headerText))) {

--- a/src/index.js
+++ b/src/index.js
@@ -22,7 +22,7 @@ export default typeof fetch=='function' ? fetch : function(url, options) {
 				keys = [],
 				all = [],
 				headers = {},
-				reg = /^(.*?)\:\s*([\s\S]*?)$/gm,
+				reg = /^(.*?):\s*([\s\S]*)$/gm,
 				match, header, key;
 
 			while ((match=reg.exec(headerText))) {

--- a/src/index.js
+++ b/src/index.js
@@ -13,9 +13,7 @@ export default typeof fetch=='function' ? fetch : function(url, options) {
 			resolve(response(request));
 		};
 
-		request.onerror = () => {
-			reject(Error('Network Error'));
-		};
+		request.onerror = reject;
 
 		request.send(options.body || null);
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-export default function fetch(url, options) {
+export default typeof fetch=='function' ? fetch : function(url, options) {
 	options = options || {};
 	return new Promise( (resolve, reject) => {
 		let request = new XMLHttpRequest();

--- a/src/index.js
+++ b/src/index.js
@@ -10,20 +10,21 @@ export default typeof fetch=='function' ? fetch : function(url, options) {
 		}
 
 		request.onload = () => {
-			resolve(response(request));
+			resolve(response());
 		};
 
 		request.onerror = reject;
 
 		request.send(options.body);
 
-		function response(xhr) {
-			let headerText = xhr.getAllResponseHeaders(),
+		function response() {
+			let headerText = request.getAllResponseHeaders(),
 				keys = [],
 				all = [],
 				headers = {},
 				reg = /^\s*(.*?)\s*\:\s*([\s\S]*?)\s*$/gm,
 				match, header, key;
+
 			while ((match=reg.exec(headerText))) {
 				keys.push(key = match[1].toLowerCase());
 				all.push([key, match[2]]);
@@ -32,16 +33,14 @@ export default typeof fetch=='function' ? fetch : function(url, options) {
 			}
 
 			return {
-				type: 'cors',
-				ok: xhr.status/200|0 == 1,		// 200-399
-				status: xhr.status,
-				statusText: xhr.statusText,
-				url: xhr.responseURL,
-				clone: () => response(xhr),
-				text: () => Promise.resolve(xhr.responseText),
-				json: () => Promise.resolve(xhr.responseText).then(JSON.parse),
-				xml: () => Promise.resolve(xhr.responseXML),
-				blob: () => Promise.resolve(xhr.response),
+				ok: request.status/200|0 == 1,		// 200-399
+				status: request.status,
+				statusText: request.statusText,
+				url: request.responseURL,
+				clone: () => response(request),
+				text: () => Promise.resolve(request.responseText),
+				json: () => Promise.resolve(request.responseText).then(JSON.parse),
+				xml: () => Promise.resolve(request.responseXML),
 				headers: {
 					keys: () => keys,
 					entries: () => all,

--- a/src/index.js
+++ b/src/index.js
@@ -41,6 +41,7 @@ export default typeof fetch=='function' ? fetch : function(url, options) {
 				text: () => Promise.resolve(request.responseText),
 				json: () => Promise.resolve(request.responseText).then(JSON.parse),
 				xml: () => Promise.resolve(request.responseXML),
+				blob: () => Promise.resolve(new Blob([request.response])),
 				headers: {
 					keys: () => keys,
 					entries: () => all,

--- a/src/index.js
+++ b/src/index.js
@@ -33,7 +33,7 @@ export default typeof fetch=='function' ? fetch : function(url, options) {
 			}
 
 			return {
-				ok: request.status/200|0 == 1,		// 200-399
+				ok: (request.status/200|0) == 1,		// 200-399
 				status: request.status,
 				statusText: request.statusText,
 				url: request.responseURL,

--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,7 @@ export default typeof fetch=='function' ? fetch : function(url, options) {
 
 		request.onerror = reject;
 
-		request.send(options.body || null);
+		request.send(options.body);
 
 		function response(xhr) {
 			let headerText = xhr.getAllResponseHeaders(),

--- a/src/index.js
+++ b/src/index.js
@@ -22,7 +22,7 @@ export default typeof fetch=='function' ? fetch : function(url, options) {
 				keys = [],
 				all = [],
 				headers = {},
-				reg = /^\s*(.*?)\s*\:\s*([\s\S]*?)\s*$/gm,
+				reg = /^(.*?)\:\s*([\s\S]*?)$/gm,
 				match, header, key;
 
 			while ((match=reg.exec(headerText))) {

--- a/test/index.js
+++ b/test/index.js
@@ -44,7 +44,7 @@ describe('unfetch', () => {
 
 					expect(xhr.setRequestHeader).to.have.been.calledOnce.and.calledWith('a', 'b');
 					expect(xhr.open).to.have.been.calledOnce.and.calledWith('get', '/foo');
-					expect(xhr.send).to.have.been.calledOnce.and.calledWith(null);
+					expect(xhr.send).to.have.been.calledOnce.and.calledWith();
 
 					delete global.XMLHttpRequest;
 				});


### PR DESCRIPTION
I managed to find optimizations that actually reduce the size overall, while adding a few new features like `withCredentials`.

Fixes `withCredentials` (#4/#9) and switches to a ponyfill with `/polyfill` option (#7/#19).

/cc @ajoslin @iamakulov @lixiaoyan @Tiendq @rauschma @tunnckoCore