### PR TITLE
RFC: Add isomorphic-unfetch package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 /dist
-/test-reports
-/node_modules
-/npm-debug.log
+node_modules
+npm-debug.log
 .DS_Store

--- a/packages/isomorphic-unfetch/browser.js
+++ b/packages/isomorphic-unfetch/browser.js
@@ -1,0 +1,1 @@
+module.exports = window.fetch = require('unfetch');

--- a/packages/isomorphic-unfetch/index.js
+++ b/packages/isomorphic-unfetch/index.js
@@ -1,0 +1,3 @@
+module.exports = global.fetch = typeof process=='undefined' ? require('unfetch') : (function(url, opts) {
+	return require('node-fetch')(url.replace(/^\/\//g,'https://'), opts);
+});

--- a/packages/isomorphic-unfetch/package.json
+++ b/packages/isomorphic-unfetch/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "isomorphic-unfetch",
+  "description": "Switches between unfetch & node-fetch for client & server.",
+  "browser": "browser.js",
+  "main": "index.js",
+  "dependencies": {
+    "node-fetch": "^1.6.3",
+    "unfetch": "^2.1.0"
+  }
+}


### PR DESCRIPTION
Same repo/project, separate package.  Currently a polyfill, but maybe it'd be better a ponyfill?  `node-fetch` is already set up that way.

```js
import fetch from 'isomorphic-unfetch';

// in node, `fetch()` is node-fetch
// in browser `fetch()` is (fetch || unfetch)
```

/cc @impronunciable @arunoda