### PR TITLE
Add caveats to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,50 @@ fetch('/bear', {
 })
 ```
 
+### Caveats
+
+_Adopted from the GitHub fetch polyfill [**readme**](https://github.com/github/fetch#caveats)_
+
+The `fetch` specification differs from `jQuery.ajax()` in mainly two ways that
+bear keeping in mind:
+
+* By default, `fetch` **won't send or receive any cookies** from the server,
+  resulting in unauthenticated requests if the site relies on maintaining a user
+  session.
+
+```javascript
+fetch('/users', {
+  credentials: 'include'
+});
+```
+
+* The Promise returned from `fetch()` **won't reject on HTTP error status**
+  even if the response is an HTTP 404 or 500. Instead, it will resolve normally,
+  and it will only reject on network failure or if anything prevented the
+  request from completing.
+
+  To have `fetch` Promise reject on HTTP error statuses, i.e. on any non-2xx
+  status, define a custom response handler:
+
+```javascript
+function checkStatus(response) {
+  if (response.status >= 200 && response.status < 300) {
+    return response;
+  } else {
+    var error = new Error(response.statusText);
+    error.response = response;
+    throw error;
+  }
+}
+
+fetch('/users')
+  .then( checkStatus )
+  .then( r => r.json() )
+  .then( data => {
+    console.log(data);
+  });
+```
+
 * * *
 
 ## Contribute

--- a/README.md
+++ b/README.md
@@ -113,9 +113,9 @@ fetch('/bear', {
 })
 ```
 
-### Caveats
+## Caveats
 
-_Adopted from the GitHub fetch polyfill [**readme**](https://github.com/github/fetch#caveats)_
+_Adapted from the GitHub fetch polyfill [**readme**](https://github.com/github/fetch#caveats)._
 
 The `fetch` specification differs from `jQuery.ajax()` in mainly two ways that
 bear keeping in mind:

--- a/README.md
+++ b/README.md
@@ -139,22 +139,22 @@ fetch('/users', {
   status, define a custom response handler:
 
 ```javascript
-function checkStatus(response) {
-  if (response.status >= 200 && response.status < 300) {
-    return response;
-  } else {
-    var error = new Error(response.statusText);
-    error.response = response;
-    throw error;
-  }
-}
-
 fetch('/users')
   .then( checkStatus )
   .then( r => r.json() )
   .then( data => {
     console.log(data);
   });
+
+function checkStatus(response) {
+  if (response.ok) {
+    return response;
+  } else {
+    var error = new Error(response.statusText);
+    error.response = response;
+    return Promise.reject(error);
+  }
+}
 ```
 
 * * *


### PR DESCRIPTION
This fixes #29.

I decided to copy/paste/adjust the caveats because the GitHub polyfill README talks about setting `credentials` to `same-origin`, which does not work for unfetch.

I have adjusted the code from GitHub slightly:
 - Added semicolons.
 - Remove the custom JSON response handler from the `checkStatus` example.