### PR TITLE
Extract the ponyfill out from unfetch.

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -6,7 +6,7 @@ let { FORMAT } = process.env;
 export default {
 	useStrict: false,
 	sourceMap: true,
-	entry: 'src/index.js',
+	entry: 'src/ponyfill.js',
 	plugins: [
 		buble(),
 		FORMAT==='cjs' && replace({

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-export default typeof fetch=='function' ? fetch : function(url, options) {
+export default function(url, options) {
 	options = options || {};
 	return new Promise( (resolve, reject) => {
 		let request = new XMLHttpRequest();

--- a/src/ponyfill.js
+++ b/src/ponyfill.js
@@ -1,0 +1,2 @@
+import unfetch from './index'
+export default typeof fetch == 'function' ? fetch : unfetch


### PR DESCRIPTION
This sets up making unfetch available as a module you would use instead of fetch in ALL cases.