### PR TITLE
Added `API` Section (#39)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@
 -   [Usage](#usage)
 -   [Examples & Demos](#examples--demos)
 -   [API](#api)
+-   [Caveats](#caveats)
 -   [Contribute](#contribute)
 -   [License](#license)
 
@@ -112,6 +113,44 @@ fetch('/bear', {
   return r.json();
 })
 ```
+
+## API
+While one of Unfetch's goals is to provide a familiar interface, it's API may differ from other `fetch` polyfills/ponyfills. 
+One of the key differences is that Unfetch focuses on implementing the [`fetch()` API](https://fetch.spec.whatwg.org/#fetch-api), while offering minimal (yet functional) support to the other sections of the [Fetch spec](https://fetch.spec.whatwg.org/), like the [Headers class](https://fetch.spec.whatwg.org/#headers-class) or the [Response class](https://fetch.spec.whatwg.org/#response-class).
+Unfetch's API is organized as follows:
+
+### `fetch(url: string, options: Object)`
+This function is the heart of Unfetch. It will fetch resources from `url` according to the given `options`, returning a Promise that will eventually resolve to the response.
+
+Unfetch will account for the following properties in `options`:
+  
+  * `method`: Indicates the request method to be performed on the
+   target resource (The most common ones being `GET`, `POST`, `PUT`, `PATCH`, `HEAD`, `OPTIONS` or `DELETE`).
+  * `headers`: An `Object` containing additional information to be sent with the request, e.g. `{ 'Content-Type': 'application/json' }` to indicate a JSON-typed request body.
+  * `credentials`: ⚠ Accepts a `"include"` string, which will allow both CORS and same origin requests to work with cookies. As pointed in the ['Caveats' section](#caveats), Unfetch won't send or receive cookies otherwise. The `"same-origin"` value is not supported. ⚠
+  * `body`: The content to be transmited in request's body. Common content types include `FormData`, `JSON`, `Blob`, `ArrayBuffer` or plain text.
+
+### `response` Methods and Attributes
+These methods are used to handle the response accordingly in your Promise chain. Instead of implementing full spec-compliant [Response Class](https://fetch.spec.whatwg.org/#response-class) functionality, Unfetch provides the following methods and attributes:
+
+#### `response.ok`
+Returns `true` if the request received a status in the `OK` range. 
+> ⚠ Unfetch considers any status in the range of `200` to `399` as `OK`, differing from [the spec which categorizes some statuses in that range as `redirect`](https://fetch.spec.whatwg.org/#statuses). 
+#### `response.status`
+Contains the status code of the response, e.g. `404` for a not found resource, `200` for a success.
+#### `response.statusText`
+A message related to the `status` attribute, e.g. `OK` for a status `200`.
+#### `response.clone()`
+Will return another `Object` with the same shape and content as `response`.
+#### `response.text()`, `response.json()`, `response.xml()`, `response.blob()`
+Will return the response content as plain text, JSON, XML and `Blob`, respectively.
+
+#### `response.headers`
+Again, Unfetch doesn't implement a full spec-compliant [`Headers Class`](https://fetch.spec.whatwg.org/#headers), emulating some of the Map-like functionality through its own functions:
+  * `headers.keys`: Returns an `Array` containing the `key` for every header in the response.
+  * `headers.entries`: Returns an `Array` containing the `[key, value]` pairs for every `Header` in the response.
+  * `headers.get(key)`: Returns the `value` associated with the given `key`.
+  * `headers.has(key)`: Returns a `boolean` asserting the existence of a `value` for the given `key` among the response headers.
 
 ## Caveats
 


### PR DESCRIPTION
As pointed out in #39, there's no section explaining the API. This PR adds that section to the README. 