### PR TITLE
Remove invented xml() method

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 > Tiny 500b fetch "barely-polyfill"
 
 -   **Tiny:** under **500 bytes** of [ES3](https://unpkg.com/unfetch) gzipped
--   **Minimal:** just `fetch()` with headers and text/json/xml responses
+-   **Minimal:** just `fetch()` with headers and text/json responses
 -   **Familiar:** a subset of the full API
 -   **Supported:** supports IE8+ _(assuming `Promise` is polyfilled of course!)_
 -   **Standalone:** one function, no dependencies
@@ -145,8 +145,8 @@ A message related to the `status` attribute, e.g. `OK` for a status `200`.
 #### `response.clone()`
 Will return another `Object` with the same shape and content as `response`.
 
-#### `response.text()`, `response.json()`, `response.xml()`, `response.blob()`
-Will return the response content as plain text, JSON, XML and `Blob`, respectively.
+#### `response.text()`, `response.json()`, `response.blob()`
+Will return the response content as plain text, JSON and `Blob`, respectively.
 
 #### `response.headers`
 Again, Unfetch doesn't implement a full spec-compliant [`Headers Class`](https://fetch.spec.whatwg.org/#headers), emulating some of the Map-like functionality through its own functions:

--- a/src/index.js
+++ b/src/index.js
@@ -40,7 +40,6 @@ export default typeof fetch=='function' ? fetch : function(url, options) {
 				clone: response,
 				text: () => Promise.resolve(request.responseText),
 				json: () => Promise.resolve(request.responseText).then(JSON.parse),
-				xml: () => Promise.resolve(request.responseXML),
 				blob: () => Promise.resolve(new Blob([request.response])),
 				headers: {
 					keys: () => keys,

--- a/test/index.js
+++ b/test/index.js
@@ -29,7 +29,6 @@ describe('unfetch', () => {
 				.then( r => {
 					expect(r).to.have.property('text').that.is.a('function');
 					expect(r).to.have.property('json').that.is.a('function');
-					expect(r).to.have.property('xml').that.is.a('function');
 					expect(r).to.have.property('blob').that.is.a('function');
 					expect(r).to.have.property('clone').that.is.a('function');
 					expect(r).to.have.property('headers');


### PR DESCRIPTION
Fixes #43 by removing the `.xml()` method (and affiliates)! 