### PR TITLE
Fix error: response.ok should equal false for status codes in the 300-399 range

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -33,7 +33,7 @@ export default typeof fetch=='function' ? fetch.bind() : function(url, options) 
 			});
 
 			return {
-				ok: (request.status/200|0) == 1,		// 200-299
+				ok: (request.status/100|0) == 2,		// 200-299
 				status: request.status,
 				statusText: request.statusText,
 				url: request.responseURL,


### PR DESCRIPTION
This is the current way of checking if the response is ok:

```javascript
(request.status/200|0) == 1
```

But this gives false positives for any status code between 300-399:

```javascript
(199/200|0) == 1 // false
(200/200|0) == 1 // true
(299/200|0) == 1 // true
(300/200|0) == 1 // true <-- not expected
(399/200|0) == 1 // true <-- not expected
(400/200|0) == 1 // false
```

This pull request modifies the check to this:

```javascript
(request.status/100|0) == 2
```

Which gives us the expected results:

```javascript
(199/100|0) == 2 // false
(200/100|0) == 2 // true
(299/100|0) == 2 // true
(300/100|0) == 2 // false
```