### PR TITLE
Fix xhr request being sync by default

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,7 @@ export default typeof fetch=='function' ? fetch.bind() : function(url, options) 
 	return new Promise( (resolve, reject) => {
 		let request = new XMLHttpRequest();
 
-		request.open(options.method || 'get', url);
+		request.open(options.method || 'get', url, true);
 
 		for (let i in options.headers) {
 			request.setRequestHeader(i, options.headers[i]);


### PR DESCRIPTION
`XMLHttpRequest#open` by default has `sync` request. i.e. it's `.open(method, url, false)` by default. At least that's how XHR was at first and how it's still in Internet Explorer. Modern browsers changed that, well, because sync is bad. Anyway, here is the fix.