### PR TITLE
Update README with link to isomorphic-unfetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 >
 > -   Uses simple Arrays instead of Iterables, since Arrays _are_ iterables
 > -   No streaming, just Promisifies existing XMLHttpRequest response bodies
-> -   No server-side usage, see [isomorphic-unfetch](https://github.com/developit/unfetch/tree/master/packages/isomorphic-unfetch) if you need to support Node.js
+> -   Use in Node.JS is handled by [isomorphic-unfetch](https://github.com/developit/unfetch/tree/master/packages/isomorphic-unfetch)
 
 * * *
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
 >
 > -   Uses simple Arrays instead of Iterables, since Arrays _are_ iterables
 > -   No streaming, just Promisifies existing XMLHttpRequest response bodies
+> -   No server-side usage, see [isomorphic-unfetch](https://github.com/developit/unfetch/tree/master/packages/isomorphic-unfetch) if you need to support Node.js
 
 * * *
 


### PR DESCRIPTION
It was not immediately obvious that there was a way to support node until looking at the source.

This adds a link to in the README 📝 