### PR TITLE
Updated README to send body in POST request

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,11 +103,12 @@ fetch('/foo')
 
 
 // complex POST request with JSON, headers:
+const myHeaders = new Headers();
+myHeaders.append('Content-Type', 'application/json');
+
 fetch('/bear', {
   method: 'POST',
-  headers: {
-    'Content-Type': 'application/json'
-  },
+  headers: myHeaders,
   body: JSON.stringify({ hungry: true })
 }).then( r => {
   open(r.headers.get('location'));


### PR DESCRIPTION
When I used POST request example, it didn't send the body. This PR is to update the code in README that sends body.

This fix is posted in this [issue](https://github.com/matthew-andrews/isomorphic-fetch/issues/34#issuecomment-221379634)