### PR TITLE
Extract ponyfill (alternative to #37)

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf dist && mkdirp dist",
     "rollup:cjs": "cross-env FORMAT=cjs rollup -c rollup.config.js -f cjs -n $npm_package_name -o $npm_package_main",
     "rollup:umd": "cross-env FORMAT=umd rollup -c rollup.config.js -f umd -n $npm_package_name -o $npm_package_umd_main",
-    "rollup:esm": "rollup -c rollup.config.js -f es -n $npm_package_name -o $npm_package_module",
+    "rollup:esm": "cross-env FORMAT=esm rollup -c rollup.config.js -f es -n $npm_package_name -o $npm_package_module",
     "minify:cjs": "uglifyjs $npm_package_main -cm toplevel -o $npm_package_main -p relative --in-source-map ${npm_package_main}.map --source-map ${npm_package_main}.map",
     "minify:umd": "uglifyjs $npm_package_umd_main -cm -o $npm_package_umd_main -p relative --in-source-map ${npm_package_umd_main}.map --source-map ${npm_package_umd_main}.map",
     "size": "echo \"Gzipped Size: $(strip-json-comments --no-whitespace $npm_package_main | gzip-size)\"",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -3,6 +3,8 @@ import replace from 'rollup-plugin-post-replace';
 
 let { FORMAT } = process.env;
 
+let polyfill = 'typeof fetch==\'function\' ? fetch.bind() : '
+
 export default {
 	useStrict: false,
 	sourceMap: true,
@@ -11,11 +13,15 @@ export default {
 		buble(),
 		FORMAT==='cjs' && replace({
 			'module.exports = index;': '',
-			'var index =': 'module.exports ='
+			'var index =': `module.exports = ${polyfill}`
 		}),
 		FORMAT==='umd' && replace({
 			'return index;': '',
-			'var index =': 'return'
+			'var index =': `return ${polyfill}`
+		}),
+		FORMAT==='esm' && replace({
+			'export default index;': '',
+			'var index =': `export default ${polyfill}`
 		})
 	]
 };

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-export default typeof fetch=='function' ? fetch.bind() : function(url, options) {
+export default function(url, options) {
 	options = options || {};
 	return new Promise( (resolve, reject) => {
 		let request = new XMLHttpRequest();


### PR DESCRIPTION
Workaround to allow extracting ponyfill and keeping size from increasing

Alternative to #37 

Ignore if moving the polyfill code into rollup is not something you're willing to explore. Though I don't see an alternative to keep the size the same.