### PR TITLE
Serve the right file for browsers

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "unfetch",
   "version": "3.0.0",
   "description": "Bare minimum fetch polyfill in 500 bytes",
+  "browser": "dist/unfetch.umd.js",
   "main": "dist/unfetch.js",
   "module": "dist/unfetch.es.js",
   "jsnext:main": "dist/unfetch.es.js",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "unfetch",
   "version": "3.0.0",
   "description": "Bare minimum fetch polyfill in 500 bytes",
-  "browser": "dist/unfetch.umd.js",
+  "unpkg": "dist/unfetch.umd.js",
   "main": "dist/unfetch.js",
   "module": "dist/unfetch.es.js",
   "jsnext:main": "dist/unfetch.es.js",


### PR DESCRIPTION
I think it's becoming a common technique to point at latest package via `https://unpkg.com/pkg-name` for either development or blog posts, so that any script that points at that would point at the right version for the browser.

In this case, serving via unpkg the CJS file makes no sense so I hope this PR will be accepted and let anyone use `<script src="https://unpkg.com/unfetch"></script>` instead of the long one `https://unpkg.com/unfetch@latest/dist/unfetch.umd.js`.

Thanks for considering this change.