### PR TITLE
Add repository field to isomorphic-unfetch package

### DIFF
--- a/packages/isomorphic-unfetch/package.json
+++ b/packages/isomorphic-unfetch/package.json
@@ -7,6 +7,7 @@
     "index.d.ts",
     "browser.js"
   ],
+  "repository": "developit/unfetch",
   "browser": "browser.js",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
I noticed greenkeeper pull requests for isomorphic-unfetch do not include release notes. Presuming this will rectify.