### PR TITLE
Use null as request body if options.body is undefined

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -17,7 +17,8 @@ export default typeof fetch=='function' ? fetch.bind() : function(url, options) 
 
 		request.onerror = reject;
 
-		request.send(options.body);
+		let requestBody = typeof options.body !== 'undefined' ? options.body : null;
+		request.send(requestBody);
 
 		function response() {
 			let keys = [],


### PR DESCRIPTION
This fixes an issue with IE11 http delete when body is missing.
(See also: https://github.com/axios/axios/issues/248)