### PR TITLE
Reuse header variable

### DIFF
--- a/src/index.mjs
+++ b/src/index.mjs
@@ -5,8 +5,9 @@ export default function(url, options) {
 
 		request.open(options.method || 'get', url, true);
 
-		for (let i in options.headers) {
-			request.setRequestHeader(i, options.headers[i]);
+		let header;
+		for (header in options.headers) {
+			request.setRequestHeader(header, options.headers[header]);
 		}
 
 		request.withCredentials = options.credentials=='include';
@@ -22,8 +23,7 @@ export default function(url, options) {
 		function response() {
 			let keys = [],
 				all = [],
-				headers = {},
-				header;
+				headers = {};
 
 			request.getAllResponseHeaders().replace(/^(.*?):[^\S\n]*([\s\S]*?)$/gm, (m, key, value) => {
 				keys.push(key = key.toLowerCase());


### PR DESCRIPTION
Shave off one more byte from plain js, and two from the polyfill. Unfortunately adds one byte to the umd build.

Before:

```
Build "unfetch" to dist:
        496 B: unfetch.js
        496 B: unfetch.mjs
        566 B: unfetch.umd.js
Build "unfetch" to polyfill:
        498 B: index.js
```

After:

```
Build "unfetch" to dist:
        495 B: unfetch.js
        496 B: unfetch.mjs
        567 B: unfetch.umd.js
Build "unfetch" to polyfill:
        496 B: index.js
```