### PR TITLE
Remove node-fetch dependency for unfetch TS definition file

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,17 +1,2 @@
-import {
-  Body as NodeBody,
-  Headers as NodeHeaders,
-  Request as NodeRequest,
-  Response as NodeResponse
-} from "node-fetch";
-
-declare namespace unfetch {
-  export type IsomorphicHeaders = Headers | NodeHeaders;
-  export type IsomorphicBody = Body | NodeBody;
-  export type IsomorphicResponse = Response | NodeResponse;
-  export type IsomorphicRequest = Request | NodeRequest
-}
-
 declare const unfetch: typeof fetch;
-
 export = unfetch;


### PR DESCRIPTION
After a chat in https://github.com/developit/unfetch/issues/96 I decided to remove the `node-fetch` imports from `unfetch` definition file as now it produces TS compiler errors.