### PR TITLE
window -> self

### DIFF
--- a/packages/isomorphic-unfetch/browser.js
+++ b/packages/isomorphic-unfetch/browser.js
@@ -1,1 +1,1 @@
-module.exports = window.fetch || (window.fetch = require('unfetch').default || require('unfetch'));
+module.exports = self.fetch || (self.fetch = require('unfetch').default || require('unfetch'));


### PR DESCRIPTION
Replace `window` with `self` to allow use in Web Workers.
The main library was [already doing this](https://github.com/developit/unfetch/blob/master/polyfill/polyfill.mjs#L2), just not `isomorphic-unfetch`.

Fixes #104.