### PR TITLE
Capture JSON parsing errors in Promise

### DIFF
--- a/src/index.mjs
+++ b/src/index.mjs
@@ -12,7 +12,7 @@ export default function(url, options) {
 			status: request.status,
 			url: request.responseURL,
 			text: () => Promise.resolve(request.responseText),
-			json: () => Promise.resolve(JSON.parse(request.responseText)),
+			json: () => Promise.resolve(request.responseText).then(JSON.parse),
 			blob: () => Promise.resolve(new Blob([request.response])),
 			clone: response,
 			headers: {


### PR DESCRIPTION
Currently invalid JSON in the response throws immediately instead of asynchronously.