### PR TITLE
Fix Typescript export definitions

### DIFF
--- a/packages/isomorphic-unfetch/index.d.ts
+++ b/packages/isomorphic-unfetch/index.d.ts
@@ -14,4 +14,4 @@ declare namespace unfetch {
 
 declare const unfetch: typeof fetch;
 
-export default unfetch;
+export = unfetch;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -14,4 +14,4 @@ declare namespace unfetch {
 
 declare const unfetch: typeof fetch;
 
-export default unfetch;
+export = unfetch;


### PR DESCRIPTION
Typescript does not support .mjs files, so the module that ends up being imported is the commonJS version (`dist/unfetch.js`). Since that file does not contain a `default` export entry, using it in Typescript results in a runtime error: `TypeError: isomorphic_unfetch_1.default is not a function`

Fix by reverting to `export =`. To use in Typescript, use the form `import * as fetch from "isomorphic-unfetch"`.