### PR TITLE
Export RequestInit interface

### DIFF
--- a/packages/isomorphic-unfetch/index.d.ts
+++ b/packages/isomorphic-unfetch/index.d.ts
@@ -2,14 +2,16 @@ import {
   Body as NodeBody,
   Headers as NodeHeaders,
   Request as NodeRequest,
-  Response as NodeResponse
+  Response as NodeResponse,
+  RequestInit as NodeRequestInit
 } from "node-fetch";
 
 declare namespace unfetch {
   export type IsomorphicHeaders = Headers | NodeHeaders;
   export type IsomorphicBody = Body | NodeBody;
   export type IsomorphicResponse = Response | NodeResponse;
-  export type IsomorphicRequest = Request | NodeRequest
+  export type IsomorphicRequest = Request | NodeRequest;
+  export type IsomorphicRequestInit = RequestInit | NodeRequestInit;
 }
 
 declare const unfetch: typeof fetch;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -2,14 +2,16 @@ import {
   Body as NodeBody,
   Headers as NodeHeaders,
   Request as NodeRequest,
-  Response as NodeResponse
+  Response as NodeResponse,
+  RequestInit as NodeRequestInit
 } from "node-fetch";
 
 declare namespace unfetch {
   export type IsomorphicHeaders = Headers | NodeHeaders;
   export type IsomorphicBody = Body | NodeBody;
   export type IsomorphicResponse = Response | NodeResponse;
-  export type IsomorphicRequest = Request | NodeRequest
+  export type IsomorphicRequest = Request | NodeRequest;
+  export type IsomorphicRequestInit = RequestInit | NodeRequestInit;
 }
 
 declare const unfetch: typeof fetch;


### PR DESCRIPTION
Exports the RequestInit interface for use in client code like described here #120. 