### PR TITLE
fix a require error in Rax babel config scenes

### DIFF
--- a/packages/isomorphic-unfetch/index.js
+++ b/packages/isomorphic-unfetch/index.js
@@ -1,5 +1,5 @@
 module.exports = global.fetch = global.fetch || (
 	typeof process=='undefined' ? (require('unfetch').default || require('unfetch')) : (function(url, opts) {
-		return require('node-fetch')(url.replace(/^\/\//g,'https://'), opts);
+		return (require('node-fetch').default || require('node-fetch'))(url.replace(/^\/\//g,'https://'), opts);
 	})
 );


### PR DESCRIPTION
In some scenes that babelrc or webpack was not configured or preset properly, there may occur an require error in node side. E.g. the demo at <https://rax.js.org/docs/guide/ssr-initial-data>

```js
import fetch from 'isomorphic-unfetch'

function Page({ stars }) {
  return <div>Rax stars: {stars}</div>
}

Page.getInitialProps = async (ctx) => {
  const res = await fetch('https://api.github.com/repos/alibaba/rax')
  const json = await res.json()
  return { stars: json.stargazers_count };
}

export default Page
```
will cause a `Error: __webpack_require__(...) is not a function  at node_modules/isomorphic-unfetch/index.js:3:9) `

index.js:3:
```js
return require('node-fetch')(url.replace(/^\/\//g,'https://'), opts);
```

and colud be solved simplely like the previous  upper while it's require in browsers
```js
return (require('node-fetch').default || require('node-fetch'))(url.replace(/^\/\//g,'https://'), opts);
```