### PR TITLE
Alternative AbortController support (#54)

### DIFF
--- a/src/index.mjs
+++ b/src/index.mjs
@@ -34,6 +34,14 @@ export default function(url, options) {
 			resolve(response());
 		};
 
+		if (options.signal) {
+			options.signal.addEventListener('abort', request.abort.bind(request));
+		}
+
+		request.onabort = () => {
+			reject(new DOMException('The user aborted a request.'));
+		};
+
 		request.onerror = reject;
 
 		request.withCredentials = options.credentials=='include';


### PR DESCRIPTION
Resolves #54.

Alternative solution to #68.
My implementation differs in the following ways:
- fetch does not override signal's abort handler (one controller can cancel many actions)
- abort results in rejection with DOMExpection and proper error message.

I polyfilled AbortController and AbortSignal in tests, because they do not exist in node env.

To consider:
- will addEventListener prevent GC from clearing unused fetch scopes?

Build:
```
Build "unfetch" to dist:
        556 B: unfetch.js.gz
        461 B: unfetch.js.br
        558 B: unfetch.mjs.gz
        464 B: unfetch.mjs.br
        629 B: unfetch.umd.js.gz
        525 B: unfetch.umd.js.br
Build "unfetch" to polyfill:
        559 B: index.js.gz
        466 B: index.js.br
```