### PR TITLE
fix: do not use uninitialised `self`

### DIFF
--- a/packages/isomorphic-unfetch/browser.js
+++ b/packages/isomorphic-unfetch/browser.js
@@ -1,1 +1,1 @@
-module.exports = self.fetch || (self.fetch = require('unfetch').default || require('unfetch'));
+module.exports = global.fetch || (global.fetch = require('unfetch').default || require('unfetch'));


### PR DESCRIPTION
This should fix snowpack and other loaders that don't expect libraries to do odd things.