### PR TITLE
fix: invalid path for export in package.json (v 5.0.0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
   },
   "exports": {
     ".": {
-      "import": "./src/index.mjs",
-      "default": "./src/index.mjs"
+      "import": "./dist/unfetch.mjs",
+      "default": "./dist/unfetch.js"
     },
     "./polyfill": {
       "default": "./polyfill/index.js"

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
   },
   "exports": {
     ".": {
-      "import": "./index.mjs",
-      "default": "./index.js"
+      "import": "./src/index.mjs",
+      "default": "./src/index.mjs"
     },
     "./polyfill": {
       "default": "./polyfill/index.js"


### PR DESCRIPTION
First of all, thanks for this library! We have been using it for quite a long time, and it works like a charm.

### Description

It seems that there are invalid values exported in the package.json https://github.com/developit/unfetch/blob/main/package.json#L18

It causes issue while using `unfetch` as a module, for instance, we use webpack and once upgraded to 5.0.0 it started to break the build with the given (not so clear, to say the least) error:
```
ERROR in ./src/index.js 1:0-30
Module not found: Error: Can't resolve 'unfetch' in '/Users/user/dev/unfetch-issue-demo/src'
resolve 'unfetch' in '/Users/user/dev/unfetch-issue-demo/src'
  Parsed request is a module
  using description file: /Users/user/dev/unfetch-issue-demo/package.json (relative path: ./src)
    Field 'browser' doesn't contain a valid alias configuration
    resolve as module
      /Users/user/dev/unfetch-issue-demo/src/node_modules doesn't exist or is not a directory
      looking for modules in /Users/user/dev/unfetch-issue-demo/node_modules
        single file module
          using description file: /Users/user/dev/unfetch-issue-demo/package.json (relative path: ./node_modules/unfetch)
            no extension
              Field 'browser' doesn't contain a valid alias configuration
              /Users/user/dev/unfetch-issue-demo/node_modules/unfetch is not a file
            .tsx
              Field 'browser' doesn't contain a valid alias configuration
              /Users/user/dev/unfetch-issue-demo/node_modules/unfetch.tsx doesn't exist
            .ts
              Field 'browser' doesn't contain a valid alias configuration
              /Users/user/dev/unfetch-issue-demo/node_modules/unfetch.ts doesn't exist
            .js
              Field 'browser' doesn't contain a valid alias configuration
              /Users/user/dev/unfetch-issue-demo/node_modules/unfetch.js doesn't exist
            .jsx
              Field 'browser' doesn't contain a valid alias configuration
              /Users/user/dev/unfetch-issue-demo/node_modules/unfetch.jsx doesn't exist
        existing directory /Users/user/dev/unfetch-issue-demo/node_modules/unfetch
...
``` 

### Demo

Here you can see an example of this issue:
https://github.com/cristianoliveira/unfetch-issue-demo

### Solution

After pointing to `src/index.mjs` it started to compile again and it is working as expected. 😄 

Let me know if this is the right solution.

### Relates to
https://github.com/developit/unfetch/issues/163
https://github.com/developit/unfetch/issues/162

